### PR TITLE
Prevent spam

### DIFF
--- a/src/rpocore/page_processors.py
+++ b/src/rpocore/page_processors.py
@@ -12,7 +12,7 @@ def support_statements(request, page):
 
 @processor_for(SupporterPage)
 def support_statistics(request, page):
-    all_supporters = Supporter.objects.all()
+    all_supporters = Supporter.objects.all().filter(user__is_active=True)
     uhh_supporters = all_supporters.filter(university='UHH')
     uhh_count = uhh_supporters.count()
     all_count = all_supporters.count()


### PR DESCRIPTION
This PR prevents inactive users (and therefore largely spam users) from showing up on the supporter page.