### PR TITLE
Fixed spam statements on supporter page

### DIFF
--- a/src/rpocore/page_processors.py
+++ b/src/rpocore/page_processors.py
@@ -6,7 +6,7 @@ from rpocore.models import SupporterPage, Supporter, SupportGroup, HomepagePage,
 
 @processor_for(SupporterPage)
 def support_statements(request, page):
-    supporters = Supporter.objects.select_related('user').all()
+    supporters = Supporter.objects.select_related('user').all().filter(user__is_active=True)
     return {'supporters': supporters}
 
 


### PR DESCRIPTION
This PR finally prevents inactive - and therefore mostly spam users - from appearing on the supporter page.